### PR TITLE
PAY-2300:Bump the chart version & disable legacy deployment on AAT

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -38,6 +38,7 @@ withPipeline(type, product, app) {
     enableDbMigration('ccpay')
     enableDockerBuild()
     installCharts()
+    disableLegacyDeploymentOnAAT()
     enableAksStagingDeployment()
     enableSlackNotifications('#cc-payments-tech')
 }

--- a/charts/ccpay-bulkscanning-api/Chart.yaml
+++ b/charts/ccpay-bulkscanning-api/Chart.yaml
@@ -3,6 +3,6 @@ appVersion: "1.0"
 description: A Helm chart for ccpay bulkscanning payments api
 name: ccpay-bulkscanning-api
 home: https://github.com/hmcts/ccpay-bulkscanning-app
-version: 0.0.5
+version: 0.0.7
 maintainers:
   - name: HMCTS Fees and Pay team


### PR DESCRIPTION
Bump up the chart version with latest configuration and disable legacy deployment on aat