### PR TITLE
PAY-2639 : DCN Field length validation modified from 17 to 21 Characters

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -181,4 +181,9 @@ temporarily supressing it as we are not impacted by it.   ]]></notes>
     <cve>CVE-2019-17531</cve>
     <cve>CVE-2017-7525</cve>
   </suppress>
+  <suppress>
+    <cpe>cpe:/a:apache_tomcat:apache_tomcat:9.0.21</cpe>
+    <cve>CVE-2019-12418</cve>
+    <cve>CVE-2019-17563</cve>
+  </suppress>
 </suppressions>

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanning/controller/PaymentControllerFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanning/controller/PaymentControllerFunctionalTest.java
@@ -91,7 +91,7 @@ public class PaymentControllerFunctionalTest {
 
     @Test
     public void testBulkScanningPaymentRequestFirst() throws Exception {
-        String[] dcn = {"98721111111111111"};
+        String[] dcn = {"987211111111111111111"};
         BulkScanPaymentRequest bulkScanPaymentRequest = createBulkScanPaymentRequest("1111222233335555",
                                                                                      dcn, "AA08", true);
 
@@ -124,7 +124,7 @@ public class PaymentControllerFunctionalTest {
             .header("ServiceAuthorization", SERVICE_TOKEN)
             .contentType(ContentType.JSON)
             .when()
-            .patch("/bulk-scan-payments/98721111111111111/status/PROCESSED");
+            .patch("/bulk-scan-payments/987211111111111111111/status/PROCESSED");
 
         Assert.assertNotNull(patchResp.andReturn().asString());
 
@@ -134,7 +134,7 @@ public class PaymentControllerFunctionalTest {
             .header("ServiceAuthorization", SERVICE_TOKEN)
             .contentType(ContentType.JSON)
             .when()
-            .patch("/bulk-scan-payments/98741111111111111/status/PROCESSED");
+            .patch("/bulk-scan-payments/987411111111111111111/status/PROCESSED");
 
         Assert.assertTrue(StringUtils.containsIgnoreCase(
             patchdcnnotexists.andReturn().asString(),
@@ -145,8 +145,8 @@ public class PaymentControllerFunctionalTest {
     @Test
     @Transactional
     public void testUpdateCaseReferenceForExceptionRecord() throws Exception {
-        String[] dcn = {"98751111111111111"};
-        String[] dcn2 = {"98761111111111111"};
+        String[] dcn = {"987511111111111111111"};
+        String[] dcn2 = {"987611111111111111111"};
 
         //Multiple envelopes with same exception record
         bulkScanPaymentRequest = createBulkScanPaymentRequest("1111222233334444", dcn,
@@ -189,7 +189,7 @@ public class PaymentControllerFunctionalTest {
     @Test
     @Transactional
     public void testMarkPaymentAsProcessed() throws Exception {
-        String[] dcn = {"98711111111111111"};
+        String[] dcn = {"987111111111111111111"};
         bulkScanPaymentRequest = createBulkScanPaymentRequest("1111222233334444",
                                                               dcn, "AA08", false);
         bulkScanConsumerService.saveInitialMetadataFromBs(bulkScanPaymentRequest);
@@ -199,7 +199,7 @@ public class PaymentControllerFunctionalTest {
             .header("ServiceAuthorization", SERVICE_TOKEN)
             .contentType(ContentType.JSON)
             .when()
-            .patch("/bulk-scan-payments/98711111111111111/status/PROCESSED");
+            .patch("/bulk-scan-payments/987111111111111111111/status/PROCESSED");
 
         //Assert.assertEquals(resultActions.andReturn().getStatusCode(), OK.value());
         Assert.assertNotNull(resultActions.andReturn().asString());
@@ -209,11 +209,11 @@ public class PaymentControllerFunctionalTest {
     public void testMatchingPaymentsFromExcelaBulkScan() throws Exception {
 
         //Request from Exela with one DCN
-        String[] dcn = {"11112222444455551"};
+        String[] dcn = {"111122224444555511111"};
         Response exelaResp = RestAssured.given()
             .header("ServiceAuthorization", SERVICE_TOKEN)
             .contentType(ContentType.JSON)
-            .body(createPaymentRequest("11112222444455551"))
+            .body(createPaymentRequest("111122224444555511111"))
             .when()
             .post("/bulk-scan-payment");
 
@@ -244,11 +244,11 @@ public class PaymentControllerFunctionalTest {
     public void testNonMatchingPaymentsFromExelaThenBulkScan() throws Exception {
 
         //Request from Exela with one DCN
-        String[] dcn = {"11112222333366661", "11112222333377771"};
+        String[] dcn = {"111122223333666611111", "111122223333777711111"};
         Response exelaResp = RestAssured.given()
             .header("ServiceAuthorization", SERVICE_TOKEN)
             .contentType(ContentType.JSON)
-            .body(createPaymentRequest("11112222333366661"))
+            .body(createPaymentRequest("111122223333666611111"))
             .when()
             .post("/bulk-scan-payment");
 
@@ -279,7 +279,7 @@ public class PaymentControllerFunctionalTest {
     @Test
     public void testMatchingBulkScanFirstThenExela() throws Exception {
         //Request from Bulk Scan with one DCN
-        String[] dcn = {"11112222333388881", "11112222333399991"};
+        String[] dcn = {"111122223333888811111", "111122223333999911111"};
 
         //Request from bulk scan with two DCN
         BulkScanPaymentRequest bulkScanPaymentRequest = createBulkScanPaymentRequest("1111222233334444",
@@ -296,7 +296,7 @@ public class PaymentControllerFunctionalTest {
         Response exelaResp = RestAssured.given()
             .header("ServiceAuthorization", SERVICE_TOKEN)
             .contentType(ContentType.JSON)
-            .body(createPaymentRequest("11112222333388881"))
+            .body(createPaymentRequest("111122223333888811111"))
             .when()
             .post("/bulk-scan-payment");
 
@@ -326,7 +326,7 @@ public class PaymentControllerFunctionalTest {
     @Test
     public void testGeneratePaymentReport_Unprocessed() throws Exception {
 
-        String[] dcn = {"11112222333344441", "11112222333344442"};
+        String[] dcn = {"111122223333444411111", "111122223333444421111"};
         String ccd = "1111222233334444";
         createTestReportData(ccd, dcn);
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
@@ -345,7 +345,7 @@ public class PaymentControllerFunctionalTest {
 
     @Test
     public void testGeneratePaymentReport_DataLoss() throws Exception {
-        String[] dcn = {"11112222333355551", "11112222333355552"};
+        String[] dcn = {"111122223333555511111", "111122223333555521111"};
         String ccd = "1111222233335555";
         createTestReportData(ccd, dcn);
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanning/model/request/BulkScanPayment.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanning/model/request/BulkScanPayment.java
@@ -32,7 +32,7 @@ public class BulkScanPayment {
     @NotBlank(message = "document_control_number can't be Blank")
     @JsonProperty("document_control_number")
     @Pattern(regexp="-?\\d+(\\.\\d+)?", message = "document_control_number should be numeric")
-    @Size(min = 17, max = 17, message = "document_control_number length must be 17 digits")
+    @Size(min = 21, max = 21, message = "document_control_number length must be 21 digits")
     private String dcnReference;
     /*
     Payment amount in GBP

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanning/model/request/BulkScanPaymentRequest.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanning/model/request/BulkScanPaymentRequest.java
@@ -51,10 +51,10 @@ public class BulkScanPaymentRequest {
     }
 
     @JsonIgnore
-    @AssertFalse(message = "document_control_number must be 17 digit numeric")
+    @AssertFalse(message = "document_control_number must be 21 digit numeric")
     public boolean isValidDocumentControlNumbers() {
         return documentControlNumbers != null
-            && (Arrays.asList(documentControlNumbers).stream().anyMatch(dcn -> dcn.length() != 17)
+            && (Arrays.asList(documentControlNumbers).stream().anyMatch(dcn -> dcn.length() != 21)
             || Arrays.asList(documentControlNumbers).stream().anyMatch(dcn -> ! dcn.matches("-?\\d+(\\.\\d+)?")));
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanning/model/request/SearchRequest.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanning/model/request/SearchRequest.java
@@ -33,7 +33,7 @@ public class SearchRequest {
     private String exceptionRecord;
 
     @NotNull(message = "document_control_number can't be Blank")
-    @Size(min = 17, max = 17, message = "document_control_number length must be 17 Characters")
+    @Size(min = 21, max = 21, message = "document_control_number length must be 21 Characters")
     @Pattern(regexp="-?\\d+(\\.\\d+)?", message = "document_control_number should be numeric")
     private String documentControlNumber;
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanning/controller/PaymentControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanning/controller/PaymentControllerTest.java
@@ -69,7 +69,7 @@ public class PaymentControllerTest {
 
         ResultActions resultActions = mockMvc.perform(post("/bulk-scan-payment")
                                                       .header("ServiceAuthorization", "service")
-                                                      .content(asJsonString(createPaymentRequest("11112222333344441")))
+                                                      .content(asJsonString(createPaymentRequest("111122223333444411111")))
                                                       .contentType(MediaType.APPLICATION_JSON));
         Assert.assertEquals(Integer.valueOf(201), Integer.valueOf(resultActions.andReturn().getResponse().getStatus()));
     }
@@ -79,7 +79,7 @@ public class PaymentControllerTest {
 
         Optional<PaymentMetadata> paymentMetadata = Optional.of(PaymentMetadata.paymentMetadataWith()
                                                                     .id(1).amount(BigDecimal.valueOf(100))
-                                                                    .dcnReference("11112222333344441")
+                                                                    .dcnReference("111122223333444411111")
                                                                     .dateBanked(LocalDateTime.now())
                                                                     .paymentMethod(CHEQUE.toString()).currency(GBP.toString())
                                                                     .build());
@@ -87,7 +87,7 @@ public class PaymentControllerTest {
         when(paymentService.getPaymentMetadata(any(String.class))).thenReturn(paymentMetadata.get());
         ResultActions resultActions = mockMvc.perform(post("/bulk-scan-payment")
                                                           .header("ServiceAuthorization", "service")
-                                                          .content(asJsonString(createPaymentRequest("11112222333344441")))
+                                                          .content(asJsonString(createPaymentRequest("111122223333444411111")))
                                                           .contentType(MediaType.APPLICATION_JSON));
         Assert.assertEquals(Integer.valueOf(409), Integer.valueOf(resultActions.andReturn().getResponse().getStatus()));
     }
@@ -99,7 +99,7 @@ public class PaymentControllerTest {
             .thenThrow(new PaymentException("Exception in fetching Metadata"));
         ResultActions resultActions = mockMvc.perform(post("/bulk-scan-payment")
                                                           .header("ServiceAuthorization", "service")
-                                                          .content(asJsonString(createPaymentRequest("11112222333344441")))
+                                                          .content(asJsonString(createPaymentRequest("111122223333444411111")))
                                                           .contentType(MediaType.APPLICATION_JSON));
         Assert.assertEquals(true, resultActions.andReturn().getResponse()
             .getContentAsString().contains("Exception in fetching Metadata"));
@@ -109,7 +109,7 @@ public class PaymentControllerTest {
    @Test
    @Transactional
    public void testCreatePaymentForBulkScan() throws Exception{
-       String dcn[] = {"98711111111111111","98721111111111111"};
+       String dcn[] = {"987111111111111111111","987211111111111111111"};
        BulkScanPaymentRequest bulkScanPaymentRequest = createBulkScanPaymentRequest(CCD_CASE_REFERENCE
            ,dcn,"AA08");
 
@@ -142,7 +142,7 @@ public class PaymentControllerTest {
     @Test
     @Transactional
     public void testMarkPaymentAsProcessed() throws Exception{
-        ResultActions resultActions = mockMvc.perform(patch("/bulk-scan-payments/98721111111111111/status/PROCESSED")
+        ResultActions resultActions = mockMvc.perform(patch("/bulk-scan-payments/987211111111111111111/status/PROCESSED")
           .header("Authorization", "user")
           .header("ServiceAuthorization", "service")
           .contentType(MediaType.APPLICATION_JSON));

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanning/controller/SearchControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanning/controller/SearchControllerTest.java
@@ -91,7 +91,7 @@ public class SearchControllerTest {
         when(searchService.retrieveByDcn(any(String.class)))
             .thenReturn(searchResponse);
         ResultActions resultActions = mockMvc.perform(get("/cases")
-                                                          .param("document_control_number", "98712311111111111")
+                                                          .param("document_control_number", "987123111111111111111")
                                                           .header("Authorization", "user")
                                                           .header("ServiceAuthorization", "service")
                                                           .accept(MediaType.APPLICATION_JSON));
@@ -103,7 +103,7 @@ public class SearchControllerTest {
         SearchResponse searchResponse = null;
         when(searchService.retrieveByDcn(any(String.class))).thenReturn(searchResponse);
         ResultActions resultActions = mockMvc.perform(get("/cases")
-                                                          .param("document_control_number", "98712311111111111")
+                                                          .param("document_control_number", "987123111111111111111")
                                                           .header("Authorization", "user")
                                                           .header("ServiceAuthorization", "service")
                                                           .accept(MediaType.APPLICATION_JSON));
@@ -114,7 +114,7 @@ public class SearchControllerTest {
     public void testSearchPaymentWithDcn_Exception() throws Exception{
         when(searchService.retrieveByDcn(any(String.class))).thenThrow(new PaymentException("Exception in fetching Payments"));
         ResultActions resultActions = mockMvc.perform(get("/cases")
-                                                          .param("document_control_number", "98712311111111111")
+                                                          .param("document_control_number", "987123111111111111111")
                                                           .header("Authorization", "user")
                                                           .header("ServiceAuthorization", "service")
                                                           .accept(MediaType.APPLICATION_JSON));

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanning/functionaltest/PaymentControllerFnTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanning/functionaltest/PaymentControllerFnTest.java
@@ -108,7 +108,7 @@ public class PaymentControllerFnTest {
 
     @Test
     public void testBulkScanningPaymentRequestFirst() throws Exception{
-        String dcn[] = {"98721111111111111"};
+        String dcn[] = {"987211111111111111111"};
         BulkScanPaymentRequest bulkScanPaymentRequest = createBulkScanPaymentRequest("1111222233335555"
             ,dcn,"AA08", true);
 
@@ -126,12 +126,12 @@ public class PaymentControllerFnTest {
         ));
 
         //PATCH Request
-        ResultActions patchRequest = restActions.patch("/bulk-scan-payments/98721111111111111/status/PROCESSED");
+        ResultActions patchRequest = restActions.patch("/bulk-scan-payments/987211111111111111111/status/PROCESSED");
 
         Assert.assertNotNull(patchRequest.andReturn().getResponse().getContentAsString());
 
         //DCN Not exists Request
-        ResultActions patchDCNNotExists = restActions.patch("/bulk-scan-payments/98741111111111111/status/PROCESSED");
+        ResultActions patchDCNNotExists = restActions.patch("/bulk-scan-payments/987411111111111111111/status/PROCESSED");
 
         Assert.assertTrue(StringUtils.containsIgnoreCase(patchDCNNotExists.andReturn().getResponse().getContentAsString(),
             DCN_NOT_EXISTS));
@@ -140,8 +140,8 @@ public class PaymentControllerFnTest {
     @Test
     @Transactional
     public void testUpdateCaseReferenceForExceptionRecord() throws Exception {
-        String dcn[] = {"98751111111111111"};
-        String dcn2[] = {"98761111111111111"};
+        String dcn[] = {"987511111111111111111"};
+        String dcn2[] = {"987611111111111111111"};
 
         //Multiple envelopes with same exception record
         bulkScanPaymentRequest = createBulkScanPaymentRequest("1111222233334444"
@@ -170,16 +170,16 @@ public class PaymentControllerFnTest {
 
     @Test
     public void testMarkPaymentAsProcessed() throws Exception {
-        String dcn[] = {"98711111111111111"};
+        String dcn[] = {"987111111111111111111"};
         bulkScanPaymentRequest = createBulkScanPaymentRequest("1111222233334444"
             , dcn, "AA08", false);
         bulkScanConsumerService.saveInitialMetadataFromBs(bulkScanPaymentRequest);
 
-        ResultActions resultActions = restActions.patch("/bulk-scan-payments/98711111111111111/status/PROCESSED");
+        ResultActions resultActions = restActions.patch("/bulk-scan-payments/987111111111111111111/status/PROCESSED");
 
         Assert.assertEquals(resultActions.andReturn().getResponse().getStatus(), OK.value());
 
-        EnvelopePayment payment1 = paymentRepository.findByDcnReference("98711111111111111").get();
+        EnvelopePayment payment1 = paymentRepository.findByDcnReference("987111111111111111111").get();
         Assert.assertEquals(PROCESSED.toString(), payment1.getPaymentStatus());
 
         //Delete Envelope for DCN 1111-2222-3333-4444
@@ -193,8 +193,8 @@ public class PaymentControllerFnTest {
     public void testMatchingPaymentsFromExcelaBulkScan() throws Exception {
 
         //Request from Exela with one DCN
-        String dcn[] = {"11112222444455551"};
-        restActions.post("/bulk-scan-payment", createPaymentRequest("11112222444455551"));
+        String dcn[] = {"111122224444555511111"};
+        restActions.post("/bulk-scan-payment", createPaymentRequest("111122224444555511111"));
 
         //Request from bulk scan with one DCN
         BulkScanPaymentRequest bulkScanPaymentRequest = createBulkScanPaymentRequest("1111222233334444"
@@ -204,7 +204,7 @@ public class PaymentControllerFnTest {
         restActions.post("/bulk-scan-payments", bulkScanPaymentRequest);
 
         //Complete payment
-        EnvelopePayment payment = paymentRepository.findByDcnReference("11112222444455551").get();
+        EnvelopePayment payment = paymentRepository.findByDcnReference("111122224444555511111").get();
         Assert.assertEquals(COMPLETE.toString(), payment.getPaymentStatus());
 
         //Complete envelope
@@ -217,8 +217,8 @@ public class PaymentControllerFnTest {
     public void testNonMatchingPaymentsFromExelaThenBulkScan() throws Exception {
 
         //Request from Exela with one DCN
-        String dcn[] = {"11112222333366661", "11112222333377771"};
-        restActions.post("/bulk-scan-payment", createPaymentRequest("11112222333366661"));
+        String dcn[] = {"111122223333666611111", "111122223333777711111"};
+        restActions.post("/bulk-scan-payment", createPaymentRequest("111122223333666611111"));
 
         //Request from bulk scan with two DCN
         BulkScanPaymentRequest bulkScanPaymentRequest = createBulkScanPaymentRequest("1111222233334444"
@@ -228,11 +228,11 @@ public class PaymentControllerFnTest {
         restActions.post("/bulk-scan-payments", bulkScanPaymentRequest);
 
         //Complete payment
-        Assert.assertEquals(paymentRepository.findByDcnReference("11112222333366661").get().getPaymentStatus()
+        Assert.assertEquals(paymentRepository.findByDcnReference("111122223333666611111").get().getPaymentStatus()
             , COMPLETE.toString());
 
         //Non Complete Payment
-        Assert.assertEquals(paymentRepository.findByDcnReference("11112222333377771").get().getPaymentStatus()
+        Assert.assertEquals(paymentRepository.findByDcnReference("111122223333777711111").get().getPaymentStatus()
             , INCOMPLETE.toString());
     }
 
@@ -240,7 +240,7 @@ public class PaymentControllerFnTest {
     @Test
     public void testMatchingBulkScanFirstThenExela() throws Exception {
         //Request from Bulk Scan with one DCN
-        String dcn[] = {"11112222333388881", "11112222333399991"};
+        String dcn[] = {"111122223333888811111", "111122223333999911111"};
 
         //Request from bulk scan with two DCN
         BulkScanPaymentRequest bulkScanPaymentRequest = createBulkScanPaymentRequest("1111222233334444"
@@ -249,22 +249,22 @@ public class PaymentControllerFnTest {
         //Post request
         restActions.post("/bulk-scan-payments", bulkScanPaymentRequest);
 
-        restActions.post("/bulk-scan-payment", createPaymentRequest("11112222333388881"));
+        restActions.post("/bulk-scan-payment", createPaymentRequest("111122223333888811111"));
 
         //Complete payment
-        Assert.assertEquals(paymentRepository.findByDcnReference("11112222333388881").get().getPaymentStatus()
+        Assert.assertEquals(paymentRepository.findByDcnReference("111122223333888811111").get().getPaymentStatus()
             , COMPLETE.toString());
 
         //Non Complete Payment
-        Assert.assertEquals(paymentRepository.findByDcnReference("11112222333399991").get().getPaymentStatus()
+        Assert.assertEquals(paymentRepository.findByDcnReference("111122223333999911111").get().getPaymentStatus()
             , INCOMPLETE.toString());
 
     }
 
     @Test
     public void testMatchingMultipleEnvelopesFromExelaBulkScan() throws Exception {
-        String dcn1 = "00001111222233331";
-        String dcn2 = "00001111222233341";
+        String dcn1 = "000011112222333311111";
+        String dcn2 = "000011112222333411111";
 
         String dcn[] = {dcn1, dcn2};
 
@@ -313,16 +313,16 @@ public class PaymentControllerFnTest {
 
         //Request from Exela with one DCN
         restActions.post("/bulk-scan-payment",
-                         createPaymentRequest("11112222333312345"));
+                         createPaymentRequest("111122223333123451111"));
 
         //New payment should be saved with Incomplete status
-        Assert.assertEquals(paymentRepository.findByDcnReference("11112222333312345").get().getPaymentStatus()
+        Assert.assertEquals(paymentRepository.findByDcnReference("111122223333123451111").get().getPaymentStatus()
             , INCOMPLETE.toString());
     }
 
     @Test
     public void testSearchByCCDForProcessed() throws Exception {
-        String dcns[] = {"11116666777788881", "11116666777799991"};
+        String dcns[] = {"111166667777888811111", "111166667777999911111"};
         BulkScanPaymentRequest bulkScanPaymentRequest = createBulkScanPaymentRequest("1111666677774444"
             , dcns, "AA08", true);
 
@@ -330,20 +330,20 @@ public class PaymentControllerFnTest {
         restActions.post("/bulk-scan-payments", bulkScanPaymentRequest);
 
         //Payment Request from Exela for Payment DCN 1111-6666-7777-8888
-        restActions.post("/bulk-scan-payment", createPaymentRequest("11116666777788881"));
+        restActions.post("/bulk-scan-payment", createPaymentRequest("111166667777888811111"));
 
         //Payment Request from Exela for Payment DCN 1111-6666-7777-9999
-        restActions.post("/bulk-scan-payment", createPaymentRequest("11116666777799991"));
+        restActions.post("/bulk-scan-payment", createPaymentRequest("111166667777999911111"));
 
         //Update Payment Status once Payment Allocated to Fee for DCN 1111-6666-7777-8888
-        restActions.patch("/bulk-scan-payments/11116666777788881/status/PROCESSED");
+        restActions.patch("/bulk-scan-payments/111166667777888811111/status/PROCESSED");
 
         //Update Payment Status once Payment Allocated to Fee for DCN 1111-6666-7777-9999
-        restActions.patch("/bulk-scan-payments/11116666777799991/status/PROCESSED");
+        restActions.patch("/bulk-scan-payments/111166667777999911111/status/PROCESSED");
 
         //Calling Search API by DCN and validate response
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("document_control_number", "11116666777799991");
+        params.add("document_control_number", "111166667777999911111");
         ResultActions resultActions = restActions.get("/cases", params);
 
         Assert.assertEquals(200, resultActions.andReturn().getResponse().getStatus());
@@ -358,7 +358,7 @@ public class PaymentControllerFnTest {
 
     @Test
     public void testInvalidAuthorisedService() throws Exception {
-        String dcns[] = {"11116666777788882", "11116666777799992"};
+        String dcns[] = {"111166667777888821111", "111166667777999921111"};
         BulkScanPaymentRequest bulkScanPaymentRequest = createBulkScanPaymentRequest("1111666677775555"
             , dcns, "AA08", true);
 
@@ -377,7 +377,7 @@ public class PaymentControllerFnTest {
 
     @Test
     public void testInvalidAuthorisedUser() throws Exception {
-        String dcns[] = {"11116666777788882", "11116666777799992"};
+        String dcns[] = {"111166667777888821111", "111166667777999921111"};
         BulkScanPaymentRequest bulkScanPaymentRequest = createBulkScanPaymentRequest("1111666677775555"
             , dcns, "AA08", true);
 
@@ -392,7 +392,7 @@ public class PaymentControllerFnTest {
             .withReturnUrl("https://www.gooooogle.com");
         //Calling Search API by DCN and validate response
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("document_control_number", "11116666777799992");
+        params.add("document_control_number", "111166667777999921111");
         ResultActions resultActions = testRestAction.get("/cases", params);
 
         Assert.assertEquals(403, resultActions.andReturn().getResponse().getStatus());
@@ -411,7 +411,7 @@ public class PaymentControllerFnTest {
     @Test
     public void testGeneratePaymentReport_Unprocessed() throws Exception {
 
-        String dcn[] = {"11112222333344441", "11112222333344442"};
+        String dcn[] = {"111122223333444411111", "111122223333444421111"};
         String ccd = "1111222233334444";
         createTestReportData(ccd, dcn);
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
@@ -425,7 +425,7 @@ public class PaymentControllerFnTest {
 
     @Test
     public void testGeneratePaymentReport_DataLoss() throws Exception {
-        String dcn[] = {"11112222333355551", "11112222333355552"};
+        String dcn[] = {"111122223333555511111", "111122223333555521111"};
         String ccd = "1111222233335555";
         createTestReportData(ccd, dcn);
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
@@ -439,7 +439,7 @@ public class PaymentControllerFnTest {
 
     @Test
     public void testGetPaymentReportData_DataLoss() throws Exception {
-        String dcn[] = {"11112222333355551", "11112222333355552"};
+        String dcn[] = {"111122223333555511111", "111122223333555521111"};
         String ccd = "1111222233335555";
         createTestReportData(ccd, dcn);
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
@@ -453,7 +453,7 @@ public class PaymentControllerFnTest {
 
     @Test
     public void testGetPaymentReportData_Unprocessed() throws Exception {
-        String dcn[] = {"11112222333355551", "11112222333355552"};
+        String dcn[] = {"111122223333555511111", "111122223333555521111"};
         String ccd = "1111222233335555";
         createTestReportData(ccd, dcn);
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanning/service/PaymentServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanning/service/PaymentServiceTest.java
@@ -101,9 +101,9 @@ public class PaymentServiceTest {
     public static final String CCD_CASE_REFERENCE = "1111222233334444";
     public static final String CCD_CASE_REFERENCE_NOT_PRESENT = "9999888833334444";
     public static final String EXCEPTION_RECORD_REFERENCE = "4444333322221111";
-    public static final String DCN_REFERENCE = "DCN11111111111111";
+    public static final String DCN_REFERENCE = "DCN111111111111111111";
 
-    public static final String TEST_DCN_REFERENCE = "12312311111111111";
+    public static final String TEST_DCN_REFERENCE = "123123111111111111111";
 
     @Before
     public void setUp() {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanning/validator/BulkScanValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanning/validator/BulkScanValidatorTest.java
@@ -95,7 +95,7 @@ public class BulkScanValidatorTest {
                                                                                                 "123456",
                                                                                                 "2019-01-01",
                                                                                                 "GBP",
-                                                                                                "11112222333344448",
+                                                                                                "111122223333444481111",
                                                                                                 "CASH",
                                                                                                 "Unknown"));
 


### PR DESCRIPTION

### JIRA link (if applicable) ###

PAY-2639 : DCN Field length validation modified from 17 to 21 Characters

### Change description ###

PAY-2639 : DCN Field length validation modified from 17 to 21 Characters

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
