### PR TITLE
PAY-6446: Update to fix exception record not being returned

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "schedule": "after 7am and before 11am every weekday",
-  "extends": ["config:base"],
+  "extends": [
+    "local>hmcts/.github:renovate-config",
+    "local>hmcts/.github//renovate/automerge-all"
+  ],
   "labels": ["dependencies"],
   "helmv3": {
     "bumpVersion": "patch"

--- a/charts/ccpay-bulkscanning-api/Chart.yaml
+++ b/charts/ccpay-bulkscanning-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for ccpay bulkscanning payments api
 name: ccpay-bulkscanning-api
 home: https://github.com/hmcts/ccpay-bulkscanning-app
-version: 1.0.21
+version: 1.0.22
 maintainers:
   - name: HMCTS Fees and Pay team
 dependencies:

--- a/charts/ccpay-bulkscanning-api/values.preview.template.yaml
+++ b/charts/ccpay-bulkscanning-api/values.preview.template.yaml
@@ -1,7 +1,8 @@
 java:
   # Don't modify below here
   image: ${IMAGE_NAME}
-  ingressHost: ${SERVICE_NAME}.preview.platform.hmcts.net
+  ingressHost: ${SERVICE_FQDN}
+
   environment:
     POSTGRES_HOST: "{{ .Release.Name }}-postgresql"
     POSTGRES_NAME: "{{ .Values.postgresql.auth.database}}"

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanning/service/SearchServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanning/service/SearchServiceImpl.java
@@ -137,21 +137,26 @@ public class SearchServiceImpl implements SearchService {
     }
 
     private List<EnvelopeCase> getEnvelopeCaseByCcdReference(SearchRequest searchRequest) {
-        if (StringUtils.isNotEmpty(searchRequest.getCcdReference())
-            && envelopeCaseRepository.findByCcdReference(searchRequest.getCcdReference()).isPresent()
-            && !envelopeCaseRepository.findByCcdReference(searchRequest.getCcdReference()).get().isEmpty()) {
-            return envelopeCaseRepository.findByCcdReference(searchRequest.getCcdReference()).orElse(Collections.emptyList());
-        } else if (StringUtils.isNotEmpty(searchRequest.getExceptionRecord())
-            && envelopeCaseRepository.findByExceptionRecordReference(searchRequest.getExceptionRecord()).isPresent()) {
-            List<EnvelopeCase> envelopeCases = envelopeCaseRepository.findByExceptionRecordReference(searchRequest.getExceptionRecord()).orElse(Collections.emptyList());
-            for (EnvelopeCase envelopeCase : envelopeCases) {
-                if (StringUtils.isNotEmpty(envelopeCase.getCcdReference())
-                    && envelopeCaseRepository.findByCcdReference(envelopeCase.getCcdReference()).isPresent()
-                    && !envelopeCaseRepository.findByCcdReference(envelopeCase.getCcdReference()).get().isEmpty()) {
-                    return envelopeCaseRepository.findByCcdReference(envelopeCase.getCcdReference()).orElse(Collections.emptyList());
-                }
+        if (StringUtils.isNotEmpty(searchRequest.getCcdReference())) {
+            Optional<List<EnvelopeCase>> envelopeCases = envelopeCaseRepository.findByCcdReference(searchRequest.getCcdReference());
+            if (envelopeCases.isPresent() && !envelopeCases.get().isEmpty()) {
+                return envelopeCases.get();
             }
-            return envelopeCases;
+        }
+        if (StringUtils.isNotEmpty(searchRequest.getExceptionRecord())) {
+            Optional<List<EnvelopeCase>> envelopeCasesByExpRef = envelopeCaseRepository.findByExceptionRecordReference(searchRequest.getExceptionRecord());
+            if (envelopeCasesByExpRef.isPresent() && !envelopeCasesByExpRef.get().isEmpty()) {
+                for (EnvelopeCase envelopeCase : envelopeCasesByExpRef.get()) {
+                    if (StringUtils.isNotEmpty(envelopeCase.getCcdReference())) {
+                        Optional<List<EnvelopeCase>> envelopeCasesByCcdRef = envelopeCaseRepository.findByCcdReference(
+                            envelopeCase.getCcdReference());
+                        if (envelopeCasesByCcdRef.isPresent() && !envelopeCasesByCcdRef.get().isEmpty()) {
+                            return envelopeCasesByCcdRef.get();
+                        }
+                    }
+                }
+                return envelopeCasesByExpRef.get();
+            }
         }
         return Collections.emptyList();
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanning/service/SearchServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanning/service/SearchServiceImpl.java
@@ -138,6 +138,7 @@ public class SearchServiceImpl implements SearchService {
 
     private List<EnvelopeCase> getEnvelopeCaseByCcdReference(SearchRequest searchRequest) {
         if (StringUtils.isNotEmpty(searchRequest.getCcdReference())
+            && envelopeCaseRepository.findByCcdReference(searchRequest.getCcdReference()).isPresent()
             && !envelopeCaseRepository.findByCcdReference(searchRequest.getCcdReference()).get().isEmpty()) {
             return envelopeCaseRepository.findByCcdReference(searchRequest.getCcdReference()).orElse(Collections.emptyList());
         } else if (StringUtils.isNotEmpty(searchRequest.getExceptionRecord())
@@ -145,6 +146,7 @@ public class SearchServiceImpl implements SearchService {
             List<EnvelopeCase> envelopeCases = envelopeCaseRepository.findByExceptionRecordReference(searchRequest.getExceptionRecord()).orElse(Collections.emptyList());
             for (EnvelopeCase envelopeCase : envelopeCases) {
                 if (StringUtils.isNotEmpty(envelopeCase.getCcdReference())
+                    && envelopeCaseRepository.findByCcdReference(envelopeCase.getCcdReference()).isPresent()
                     && !envelopeCaseRepository.findByCcdReference(envelopeCase.getCcdReference()).get().isEmpty()) {
                     return envelopeCaseRepository.findByCcdReference(envelopeCase.getCcdReference()).orElse(Collections.emptyList());
                 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanning/service/SearchServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanning/service/SearchServiceImpl.java
@@ -138,14 +138,14 @@ public class SearchServiceImpl implements SearchService {
 
     private List<EnvelopeCase> getEnvelopeCaseByCcdReference(SearchRequest searchRequest) {
         if (StringUtils.isNotEmpty(searchRequest.getCcdReference())
-            && envelopeCaseRepository.findByCcdReference(searchRequest.getCcdReference()).isPresent()) {
+            && !envelopeCaseRepository.findByCcdReference(searchRequest.getCcdReference()).get().isEmpty()) {
             return envelopeCaseRepository.findByCcdReference(searchRequest.getCcdReference()).orElse(Collections.emptyList());
         } else if (StringUtils.isNotEmpty(searchRequest.getExceptionRecord())
             && envelopeCaseRepository.findByExceptionRecordReference(searchRequest.getExceptionRecord()).isPresent()) {
             List<EnvelopeCase> envelopeCases = envelopeCaseRepository.findByExceptionRecordReference(searchRequest.getExceptionRecord()).orElse(Collections.emptyList());
             for (EnvelopeCase envelopeCase : envelopeCases) {
                 if (StringUtils.isNotEmpty(envelopeCase.getCcdReference())
-                    && envelopeCaseRepository.findByCcdReference(envelopeCase.getCcdReference()).isPresent()) {
+                    && !envelopeCaseRepository.findByCcdReference(envelopeCase.getCcdReference()).get().isEmpty()) {
                     return envelopeCaseRepository.findByCcdReference(envelopeCase.getCcdReference()).orElse(Collections.emptyList());
                 }
             }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanning/service/SearchServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanning/service/SearchServiceTest.java
@@ -122,6 +122,30 @@ public class SearchServiceTest {
 
     @Test
     @Transactional
+    public void testRetrieveByCaseNumber() {
+        Optional<EnvelopePayment> envelopePayment = Optional.of(EnvelopePayment.paymentWith()
+                                                                    .id(1)
+                                                                    .dcnReference(TEST_DCN_REFERENCE)
+                                                                    .paymentStatus(COMPLETE.toString())
+                                                                    .build());
+        Optional<List<EnvelopePayment>> payments = Optional.of(Arrays.asList(envelopePayment.get()));
+        Optional<Envelope> envelope = Optional.of(Envelope.envelopeWith().id(1).envelopePayments(payments.get())
+                                                      .paymentStatus(COMPLETE.toString())
+                                                      .build());
+        Optional<EnvelopeCase> envelopeCase = Optional.of(EnvelopeCase.caseWith()
+                                                              .id(1)
+                                                              .envelope(envelope.get())
+                                                              .ccdReference("CCD123")
+                                                              .exceptionRecordReference("EXP123")
+                                                              .build());
+        Optional<List<EnvelopeCase>> cases = Optional.of(Arrays.asList(envelopeCase.get()));
+        when(envelopeCaseRepository.findByCcdReference("CCD123")).thenReturn(cases);
+        SearchResponse searchResponse = paymentService.retrieveByCCDReference("CCD123");
+        assertThat(searchResponse.getCcdReference()).isEqualTo("CCD123");
+    }
+
+    @Test
+    @Transactional
     public void testRetrieveByExceptionRecordReturningCase() {
         Optional<EnvelopePayment> envelopePayment = Optional.of(EnvelopePayment.paymentWith()
                                                                     .id(1)

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanning/service/SearchServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanning/service/SearchServiceTest.java
@@ -26,6 +26,7 @@ import uk.gov.hmcts.reform.bulkscanning.model.response.SearchResponse;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -173,7 +174,8 @@ public class SearchServiceTest {
                                                               .exceptionRecordReference("EXP123")
                                                               .build());
         Optional<List<EnvelopeCase>> cases = Optional.of(Arrays.asList(envelopeCase.get()));
-        when(envelopeCaseRepository.findByCcdReference("EXP123")).thenReturn(Optional.empty());
+        Optional<List<EnvelopeCase>> emptyList = Optional.of(Collections.emptyList());
+        when(envelopeCaseRepository.findByCcdReference("EXP123")).thenReturn(emptyList);
         when(envelopeCaseRepository.findByExceptionRecordReference("EXP123")).thenReturn(cases);
         when(envelopeCaseRepository.findByCcdReference("CCD123")).thenReturn(cases);
         SearchResponse searchResponse = paymentService.retrieveByCCDReference("EXP123");
@@ -198,9 +200,10 @@ public class SearchServiceTest {
                                                               .exceptionRecordReference("EXP123")
                                                               .build());
         Optional<List<EnvelopeCase>> cases = Optional.of(Arrays.asList(envelopeCase.get()));
-        when(envelopeCaseRepository.findByCcdReference("EXP123")).thenReturn(Optional.empty());
+        Optional<List<EnvelopeCase>> emptyList = Optional.of(Collections.emptyList());
+        when(envelopeCaseRepository.findByCcdReference("EXP123")).thenReturn(emptyList);
         when(envelopeCaseRepository.findByExceptionRecordReference("EXP123")).thenReturn(cases);
-        when(envelopeCaseRepository.findByCcdReference("CCD123")).thenReturn(Optional.empty());
+        when(envelopeCaseRepository.findByCcdReference("CCD123")).thenReturn(emptyList);
         SearchResponse searchResponse = paymentService.retrieveByCCDReference("EXP123");
         assertThat(searchResponse.getCcdReference()).isEqualTo(null);
         assertThat(searchResponse.getExceptionRecordReference()).isEqualTo("EXP123");

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanning/service/SearchServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanning/service/SearchServiceTest.java
@@ -211,6 +211,14 @@ public class SearchServiceTest {
 
     @Test
     @Transactional
+    public void testNoSearchParamsReturnEmptyList() {
+        SearchResponse searchResponse = paymentService.retrieveByCCDReference(null);
+        assertThat(searchResponse.getCcdReference()).isEqualTo(null);
+        assertThat(searchResponse.getExceptionRecordReference()).isEqualTo(null);
+    }
+
+    @Test
+    @Transactional
     public void testRetrieveByDcn() {
         SearchResponse searchResponse = paymentService.retrieveByDcn(TEST_DCN_REFERENCE, false);
         assertThat(searchResponse.getPayments().get(0).getDcnReference()).isEqualTo(TEST_DCN_REFERENCE);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanning/service/SearchServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanning/service/SearchServiceTest.java
@@ -122,7 +122,7 @@ public class SearchServiceTest {
 
     @Test
     @Transactional
-    public void testRetrieveByCaseNumber() {
+    public void testRetrieveByCaseNumberReturnCase() {
         Optional<EnvelopePayment> envelopePayment = Optional.of(EnvelopePayment.paymentWith()
                                                                     .id(1)
                                                                     .dcnReference(TEST_DCN_REFERENCE)
@@ -146,7 +146,17 @@ public class SearchServiceTest {
 
     @Test
     @Transactional
-    public void testRetrieveByExceptionRecordReturningCase() {
+    public void testRetrieveByCaseNumberReturnEmptyList() {
+        when(envelopeCaseRepository.findByCcdReference("CCD123")).thenReturn(Optional.empty());
+        when(envelopeCaseRepository.findByExceptionRecordReference("CCD123")).thenReturn(Optional.empty());
+        SearchResponse searchResponse = paymentService.retrieveByCCDReference("CCD123");
+        assertThat(searchResponse.getCcdReference()).isEqualTo(null);
+        assertThat(searchResponse.getExceptionRecordReference()).isEqualTo(null);
+    }
+
+    @Test
+    @Transactional
+    public void testRetrieveByExceptionRecordReturnCase() {
         Optional<EnvelopePayment> envelopePayment = Optional.of(EnvelopePayment.paymentWith()
                                                                     .id(1)
                                                                     .dcnReference(TEST_DCN_REFERENCE)
@@ -172,7 +182,7 @@ public class SearchServiceTest {
 
     @Test
     @Transactional
-    public void testRetrieveByExceptionRecordReturningExceptionRecord() {
+    public void testRetrieveByExceptionRecordReturnExceptionRecord() {
         Optional<EnvelopePayment> envelopePayment = Optional.of(EnvelopePayment.paymentWith()
                                                                     .id(1)
                                                                     .dcnReference(TEST_DCN_REFERENCE)
@@ -204,7 +214,7 @@ public class SearchServiceTest {
     }
 
     @Test
-    public void testRetrieveByDcno() {
+    public void testRetrieveByDcnInternalOff() {
         SearchResponse searchResponse = paymentService.retrieveByDcn(TEST_DCN_REFERENCE, true);
         assertThat(searchResponse.getPayments().get(0).getDcnReference()).isEqualTo(TEST_DCN_REFERENCE);
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanning/service/SearchServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanning/service/SearchServiceTest.java
@@ -122,8 +122,7 @@ public class SearchServiceTest {
 
     @Test
     @Transactional
-    public void testRetrieveByExceptionRecord() {
-        when(envelopeCaseRepository.findByCcdReference("EXP123")).thenReturn(Optional.empty());
+    public void testRetrieveByExceptionRecordReturningCase() {
         Optional<EnvelopePayment> envelopePayment = Optional.of(EnvelopePayment.paymentWith()
                                                                     .id(1)
                                                                     .dcnReference(TEST_DCN_REFERENCE)
@@ -140,10 +139,37 @@ public class SearchServiceTest {
                                                               .exceptionRecordReference("EXP123")
                                                               .build());
         Optional<List<EnvelopeCase>> cases = Optional.of(Arrays.asList(envelopeCase.get()));
+        when(envelopeCaseRepository.findByCcdReference("EXP123")).thenReturn(Optional.empty());
         when(envelopeCaseRepository.findByExceptionRecordReference("EXP123")).thenReturn(cases);
         when(envelopeCaseRepository.findByCcdReference("CCD123")).thenReturn(cases);
         SearchResponse searchResponse = paymentService.retrieveByCCDReference("EXP123");
         assertThat(searchResponse.getCcdReference()).isEqualTo("CCD123");
+    }
+
+    @Test
+    @Transactional
+    public void testRetrieveByExceptionRecordReturningExceptionRecord() {
+        Optional<EnvelopePayment> envelopePayment = Optional.of(EnvelopePayment.paymentWith()
+                                                                    .id(1)
+                                                                    .dcnReference(TEST_DCN_REFERENCE)
+                                                                    .paymentStatus(COMPLETE.toString())
+                                                                    .build());
+        Optional<List<EnvelopePayment>> payments = Optional.of(Arrays.asList(envelopePayment.get()));
+        Optional<Envelope> envelope = Optional.of(Envelope.envelopeWith().id(1).envelopePayments(payments.get())
+                                                      .paymentStatus(COMPLETE.toString())
+                                                      .build());
+        Optional<EnvelopeCase> envelopeCase = Optional.of(EnvelopeCase.caseWith()
+                                                              .id(1)
+                                                              .envelope(envelope.get())
+                                                              .exceptionRecordReference("EXP123")
+                                                              .build());
+        Optional<List<EnvelopeCase>> cases = Optional.of(Arrays.asList(envelopeCase.get()));
+        when(envelopeCaseRepository.findByCcdReference("EXP123")).thenReturn(Optional.empty());
+        when(envelopeCaseRepository.findByExceptionRecordReference("EXP123")).thenReturn(cases);
+        when(envelopeCaseRepository.findByCcdReference("CCD123")).thenReturn(Optional.empty());
+        SearchResponse searchResponse = paymentService.retrieveByCCDReference("EXP123");
+        assertThat(searchResponse.getCcdReference()).isEqualTo(null);
+        assertThat(searchResponse.getExceptionRecordReference()).isEqualTo("EXP123");
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PAY-6446


### Change description ###
Updated to correct logic around use of exception record searches broken during the Java upgrade.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
